### PR TITLE
Changed the name back to Git Source Control Provider but with the year 2017

### DIFF
--- a/GitSccProvider/BasicSccProvider.cs
+++ b/GitSccProvider/BasicSccProvider.cs
@@ -43,8 +43,8 @@ namespace GitScc
     // Everytime the version number changes VS will automatically update the menus on startup; if the version doesn't change, you will need to run manually "devenv /setup /rootsuffix:Exp" to see VSCT changes reflected in IDE
     [MsVsShell.ProvideMenuResource(1000, 1)]
     // Register a sample options page visible as Tools/Options/SourceControl/SampleOptionsPage when the provider is active
-    [MsVsShell.ProvideOptionPageAttribute(typeof(SccProviderOptions), "Source Control", "EZ-GIT Options", 106, 107, false)]
-    [ProvideToolsOptionsPageVisibility("Source Control", "EZ-GIT Options", "C4128D99-0000-41D1-A6C3-704E6C1A3DE2")]
+    [MsVsShell.ProvideOptionPageAttribute(typeof(SccProviderOptions), "Source Control", "Git Source Control Provider Options", 106, 107, false)]
+    [ProvideToolsOptionsPageVisibility("Source Control", "Git Source Control Provider Options", "C4128D99-0000-41D1-A6C3-704E6C1A3DE2")]
     // Register a sample tool window visible only when the provider is active
     [MsVsShell.ProvideToolWindow(typeof(PendingChangesToolWindow), Style = VsDockStyle.Tabbed, Orientation = ToolWindowOrientation.Bottom)]
     [MsVsShell.ProvideToolWindowVisibility(typeof(PendingChangesToolWindow), "C4128D99-0000-41D1-A6C3-704E6C1A3DE2")]
@@ -53,7 +53,7 @@ namespace GitScc
     //Register the source control provider's service (implementing IVsScciProvider interface)
     [MsVsShell.ProvideService(typeof(SccProviderService), ServiceName = "Git Source Control Service")]
     // Register the source control provider to be visible in Tools/Options/SourceControl/Plugin dropdown selector
-    [GitScc.ProvideSourceControlProvider("EZ-GIT", "#100", IsPublishSupported = true)]
+    [GitScc.ProvideSourceControlProvider("Git Source Control Provider", "#100", IsPublishSupported = true)]
     //[MsVsShell.ProvideSourceControlProvider("Git Source Control Provider 2015", "#100", "{C4128D99-0000-41D1-A6C3-704E6C1A3DE2}",
     //    "{C4128D99-2000-41D1-A6C3-704E6C1A3DE2}", "{C4128D99-1000-41D1-A6C3-704E6C1A3DE2}", IsPublishSupported = true)]
     // Pre-load the package when the command UI context is asserted (the provider will be automatically loaded after restarting the shell if it was active last time the shell was shutdown)

--- a/GitSccProvider/Resources.Designer.cs
+++ b/GitSccProvider/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace GitScc {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to EZ-GIT.
+        ///   Looks up a localized string similar to Git Source Control Provider.
         /// </summary>
         internal static string _100 {
             get {
@@ -145,7 +145,7 @@ namespace GitScc {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to EZ-GIT.
+        ///   Looks up a localized string similar to Git Source Control Provider.
         /// </summary>
         internal static string ProviderName {
             get {

--- a/GitSccProvider/Resources.resx
+++ b/GitSccProvider/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="100" xml:space="preserve">
-    <value>EZ-GIT</value>
+    <value>Git Source Control Provider</value>
   </data>
   <data name="101" xml:space="preserve">
     <value />
@@ -134,7 +134,7 @@
     <value>Resources\Images_24bit.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="ProviderName" xml:space="preserve">
-    <value>EZ-GIT</value>
+    <value>Git Source Control Provider</value>
   </data>
   <data name="SccGlyphs" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\SccGlyphs.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/GitSccProvider/SccProviderService.cs
+++ b/GitSccProvider/SccProviderService.cs
@@ -107,7 +107,7 @@ namespace GitScc
         // Make visible and enable if necessary scc related menu commands
         public int SetActive()
         {
-            Trace.WriteLine(String.Format(CultureInfo.CurrentUICulture, "EZ-GIT set active"));
+            Trace.WriteLine(String.Format(CultureInfo.CurrentUICulture, "Git Source Control Provider set active"));
             _active = true;
             GlobalCommandHook hook = GlobalCommandHook.GetInstance(_sccProvider);
             hook.HookCommand(new CommandID(VSConstants.VSStd2K, (int)VSConstants.VSStd2KCmdID.SLNREFRESH), HandleSolutionRefresh);
@@ -125,7 +125,7 @@ namespace GitScc
         // Hides and disable scc related menu commands
         public int SetInactive()
         {
-            Trace.WriteLine(String.Format(CultureInfo.CurrentUICulture, "EZ-GIT set inactive"));
+            Trace.WriteLine(String.Format(CultureInfo.CurrentUICulture, "Git Source Control Provider set inactive"));
             _active = false;
             DisableSccForSolution();
             GlobalCommandHook hook = GlobalCommandHook.GetInstance(_sccProvider);

--- a/GitSccProvider/source.extension.cs
+++ b/GitSccProvider/source.extension.cs
@@ -8,8 +8,8 @@ namespace GitScc
     static class Vsix
     {
         public const string Id = "GitSccProvider.Microsoft.88d658b3-e361-4e7f-8f4d-9e78f6e4515a";
-        public const string Name = "Easy Git Integration Tools";
-        public const string Description = "Easy Git Integration Tools (EZ-GIT) is a plug-in that integrates git with Visual Studio.";
+        public const string Name = "Git Source Control Provider 2017";
+        public const string Description = "Git Source Control Provider is a plug-in that integrates git with Visual Studio.";
         public const string Language = "en-US";
         public const string Version = "1.6.0.0";
         public const string Author = "Jon Zoss";

--- a/GitSccProvider/source.extension.resx
+++ b/GitSccProvider/source.extension.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="110" xml:space="preserve">
-    <value>Easy Git Integration Tools</value>
+    <value>Git Source Control Provider 2017</value>
   </data>
   <data name="112" xml:space="preserve">
-    <value>Easy Git Integration Tools (EZ-GIT) is a plug-in that integrates git with Visual Studio.</value>
+    <value>Git Source Control Provider is a plug-in that integrates git with Visual Studio.</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">

--- a/GitSccProvider/source.extension.vsixmanifest
+++ b/GitSccProvider/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="GitSccProvider.Microsoft.88d658b3-e361-4e7f-8f4d-9e78f6e4515a" Version="1.6.6.4" Language="en-US" Publisher="Jon Zoss" />
-    <DisplayName>Easy Git Integration Tools</DisplayName>
-    <Description xml:space="preserve">EZ-GIT (Easy Git Integration Tools) is a plug-in that integrates git with Visual Studio.</Description>
+    <DisplayName>Git Source Control Provider 2017</DisplayName>
+    <Description xml:space="preserve">Git Source Control Provider is a plug-in that integrates git with Visual Studio.</Description>
     <MoreInfo>https://github.com/jzoss/Git-Source-Control-Provider</MoreInfo>
     <License>License.txt</License>
     <ReleaseNotes>https://github.com/jzoss/Git-Source-Control-Provider/blob/master/history.md</ReleaseNotes>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Easy Git Integration Tools (EZ-GIT)
+Git Source Control Provider 2017
 ================================
 
 Introduction


### PR DESCRIPTION
Please note that I have only added "2017" where "2015" used to stay, that is, I have left any "Git Source Control Provider" without a year unchanged.